### PR TITLE
Feature/swap-info-verbose-log-level

### DIFF
--- a/.github/workflows/EssentialsPlugins-builds-caller.yml
+++ b/.github/workflows/EssentialsPlugins-builds-caller.yml
@@ -12,7 +12,7 @@ jobs:
 
   build-4Series:
     # uses: PepperDash/workflow-templates/.github/workflows/essentialsplugins-4Series-builds.yml@main 
-    uses: PepperDash/workflow-templates/.github/workflows/essentialsplugins-4Series-builds.yml@nuget-publish
+    uses: PepperDash/workflow-templates/.github/workflows/essentialsplugins-4Series-builds.yml@main
     secrets: inherit
     needs: getVersion
     if: needs.getVersion.outputs.newVersion == 'true'
@@ -21,3 +21,4 @@ jobs:
       version: ${{ needs.getVersion.outputs.version }}
       tag: ${{ needs.getVersion.outputs.tag }}
       channel: ${{ needs.getVersion.outputs.channel }}
+      bypassPackageCheck: true

--- a/src/DeviceMonitor.cs
+++ b/src/DeviceMonitor.cs
@@ -28,7 +28,7 @@ namespace epi.utilities.deviceMonitor
         {
             _props = JsonConvert.DeserializeObject<DeviceMonitorProperties>(dc.Properties.ToString());
             _overrideDigitalOutput = _props.OverrideDigitalOutputToVisibility;
-            Debug.LogInformation(this, "Made it to Device Constructor");
+            Debug.LogVerbose(this, "Made it to Device Constructor");
 			DevicesWithLogs = new List<IKeyed>(); 
         }
 
@@ -40,14 +40,14 @@ namespace epi.utilities.deviceMonitor
 		public override bool CustomActivate()
         {
 			
-            Debug.LogInformation(this, "Creating DeviceMonitor Links");
+            Debug.LogVerbose(this, "Creating DeviceMonitor Links");
 			foreach (var item in _props.Devices)
 			{
 				try
 				{
 					if (item.Value.DeviceKey != null)
 					{
-						Debug.LogInformation(this, "Creating Essentials Device : {0}", item.Value.DeviceKey);
+						Debug.LogVerbose(this, "Creating Essentials Device : {0}", item.Value.DeviceKey);
 						var newDevice = DeviceManager.GetDeviceForKey(item.Value.DeviceKey) as Device;
 
 						if (newDevice == null)
@@ -59,24 +59,24 @@ namespace epi.utilities.deviceMonitor
 
 					    if (commMonitor != null)
                         {
-                            Debug.LogVerbose(this, "{0} is an iCommunicationMonitor", newDevice.Key);
+                            Debug.LogInformation(this, "{0} is an iCommunicationMonitor", newDevice.Key);
 
                             var monitoredDevice = new MonitoredEssentialsDevice(item.Value, commMonitor, item.Key);
-                            Debug.LogVerbose(this, "{0} has been built as a monitoredEssentialsDevice", commMonitor.CommunicationMonitor.Key);
+                            Debug.LogInformation(this, "{0} has been built as a monitoredEssentialsDevice", commMonitor.CommunicationMonitor.Key);
 
 					        MonitoredEssentialsDevices.Add(item.Key, monitoredDevice);
-                            Debug.LogVerbose(this, "{0} has been Added as a monitoredEssentialsDevice", commMonitor.CommunicationMonitor.Key);
+                            Debug.LogInformation(this, "{0} has been Added as a monitoredEssentialsDevice", commMonitor.CommunicationMonitor.Key);
                             monitoredDevice.StatusMonitor.StatusChange += StatusMonitor_StatusChange;
-                            Debug.LogVerbose(this, "{0} has been registered", commMonitor.CommunicationMonitor.Key);
+                            Debug.LogInformation(this, "{0} has been registered", commMonitor.CommunicationMonitor.Key);
                             continue;
 					    }
 					    var commBasic = newDevice as IBasicCommunication;
                         if (commBasic != null)
 					    {
-                            Debug.LogVerbose(this, "{0} is an iBasicCommunication", commBasic.Key);
+                            Debug.LogInformation(this, "{0} is an iBasicCommunication", commBasic.Key);
 					        if (item.Value.CommunicationMonitor == null)
 					        {
-					            Debug.LogVerbose(this, "No Valid CommunicationMonitor for {0}", commBasic.Key);
+					            Debug.LogError(this, "No Valid CommunicationMonitor for {0}", commBasic.Key);
 					            continue;
 					        }
 
@@ -84,13 +84,13 @@ namespace epi.utilities.deviceMonitor
 					            item.Value.CommunicationMonitor);
                             if (newDeviceMonitor == null)
                             {
-                                Debug.LogVerbose(this, "Failed to build CommunicationMonitor for {0}", commBasic.Key);
+                                Debug.LogError(this, "Failed to build CommunicationMonitor for {0}", commBasic.Key);
                                 continue;
                             }                       
                             var monitoredDevice = new MonitoredEssentialsDevice(item.Value, new OnDemandCommunicationMonitorDevice(newDeviceMonitor), item.Key);
 					        if (monitoredDevice == null)
 					        {
-                                Debug.LogVerbose(this, "Failed to build OnDemandCommunicationMonitorDevice for {0}", newDeviceMonitor.Key);
+                                Debug.LogError(this, "Failed to build OnDemandCommunicationMonitorDevice for {0}", newDeviceMonitor.Key);
                                 continue;
 
 					        }
@@ -98,11 +98,11 @@ namespace epi.utilities.deviceMonitor
 					        monitoredDevice.StatusMonitor.StatusChange += StatusMonitor_StatusChange;
 					        continue;
 					    }
-						Debug.LogVerbose(this, "DeviceMonitor -- Device {0} Does not support ICommunicationMonitor", item.Value.DeviceKey);
+						Debug.LogError(this, "DeviceMonitor -- Device {0} Does not support ICommunicationMonitor", item.Value.DeviceKey);
                     }
 					else
 					{
-						Debug.LogInformation(this, "Creating Simpl Device : {0}", item.Value.Name);
+						Debug.LogVerbose(this, "Creating Simpl Device : {0}", item.Value.Name);
 						var monitoredDevice = new MonitoredSimplDevice(item.Value);
 						MonitoredSimplDevices.Add(item.Key, monitoredDevice);
 						monitoredDevice.StatusChangeEvent += StatusMonitor_StatusChange;
@@ -118,10 +118,10 @@ namespace epi.utilities.deviceMonitor
 		    {
 		        foreach (var key in _props.LogToDeviceKeys)
 		        {
-		            Debug.LogInformation(this, "Looking For Device with Log: {0}", key);
+		            Debug.LogVerbose(this, "Looking For Device with Log: {0}", key);
 		            var device = DeviceManager.GetDeviceForKey(key);
 		            if (device == null) continue;
-		            Debug.LogInformation(this, "Found Device: {0}", key);
+		            Debug.LogVerbose(this, "Found Device: {0}", key);
 		            DevicesWithLogs.Add(device);
 		        }
 		    }
@@ -163,7 +163,7 @@ namespace epi.utilities.deviceMonitor
 				status = Debug.ErrorLogLevel.Error;
 				tempErrorMessage = string.Format("Error! {0} offline.", deviceString);
 			}			
-			Debug.LogInformation(this, tempErrorMessage);
+			Debug.LogVerbose(this, tempErrorMessage);
 
             if (DevicesWithLogs.Count > 0)
 			{
@@ -193,7 +193,7 @@ namespace epi.utilities.deviceMonitor
             bridge.AddJoinMap(Key, joinMap);
 
 			Debug.LogDebug("Linking to Trilist '{0}'", trilist.ID.ToString("X"));
-			Debug.LogVerbose("Linking to DeviceMonitor: {0}", Name);
+			Debug.LogInformation("Linking to DeviceMonitor: {0}", Name);
 			
             foreach (var item in MonitoredSimplDevices)
             {
@@ -205,16 +205,16 @@ namespace epi.utilities.deviceMonitor
 
                 if (!joinMap.Joins.TryGetValue(String.Format("DeviceMonitor--{0}", key), out joinData))
                 {
-                    Debug.LogVerbose(this, "could not get joinmap data for {0}", device.Key);
+                    Debug.LogError(this, "could not get joinmap data for {0}", device.Key);
                     continue;
                 }
                 if (!joinData.Metadata.Description.EndsWith(":: SIMPL"))
                 {
-                    Debug.LogVerbose(this, "join data did not end with :: SIMPL ", joinData.Metadata.Description);
+                    Debug.LogError(this, "join data did not end with :: SIMPL ", joinData.Metadata.Description);
                     continue;
                 }
 
-                Debug.LogVerbose(this, "Linking Bridge to Simpl Device : {0} join: {1}", device.Name, joinData.JoinNumber);
+                Debug.LogInformation(this, "Linking Bridge to Simpl Device : {0} join: {1}", device.Name, joinData.JoinNumber);
                 trilist.SetStringSigAction(joinData.JoinNumber, s => device.StopTimerSerial());
 
                 trilist.SetBoolSigAction(joinData.JoinNumber, device.DeviceOnline);
@@ -239,7 +239,7 @@ namespace epi.utilities.deviceMonitor
                 if (!joinData.Metadata.Description.EndsWith(":: ESSENTIALS"))
                     continue;
 
-                Debug.LogInformation(this, "Linking Bridge to Essentials Device : {0} join: {1}", item.Name, joinData.JoinNumber);
+                Debug.LogVerbose(this, "Linking Bridge to Essentials Device : {0} join: {1}", item.Name, joinData.JoinNumber);
 
                 device.StatusMonitor.IsOnlineFeedback.LinkInputSig(trilist.BooleanInput[joinData.JoinNumber]);
                 device.StatusFeedback.LinkInputSig(trilist.UShortInput[joinData.JoinNumber]);

--- a/src/DeviceMonitor.cs
+++ b/src/DeviceMonitor.cs
@@ -12,7 +12,7 @@ using Crestron.SimplSharpPro.DeviceSupport;
 
 namespace epi.utilities.deviceMonitor
 {
-	public class DeviceMonitor : EssentialsBridgeableDevice
+	public class DeviceMonitor : EssentialsBridgeableDevice, IBridgeAdvanced
     {
         public event EventHandler<ErrorArgs> ErrorEvent;
         private readonly DeviceMonitorProperties _props;

--- a/src/MonitoredEssentialsDevice.cs
+++ b/src/MonitoredEssentialsDevice.cs
@@ -57,7 +57,7 @@ namespace epi.utilities.deviceMonitor
 
         public MonitoredEssentialsDevice(DeviceMonitorDevice deviceConfig, ICommunicationMonitor newStatusMonitorBase, string key)
         {
-            Debug.LogVerbose("{0} Entered Constructor", deviceConfig.DeviceKey);
+            Debug.LogInformation("{0} Entered Constructor", deviceConfig.DeviceKey);
             Key = key;
             NameFeedback = new StringFeedback(() => Name);
             StatusFeedback = new IntFeedback(() => (int)Status);
@@ -66,7 +66,7 @@ namespace epi.utilities.deviceMonitor
             JoinNumber = deviceConfig.JoinNumber;
             UseInRoomHealth = deviceConfig.LogToDevices;
             StatusMonitor.StatusChange += StatusMonitor_StatusChange;
-            Debug.LogVerbose("{0} Exited Constructor", deviceConfig.DeviceKey);
+            Debug.LogInformation("{0} Exited Constructor", deviceConfig.DeviceKey);
 
             TranslateStatus(newStatusMonitorBase.CommunicationMonitor.Status);
         }

--- a/src/MonitoredSimplDevice.cs
+++ b/src/MonitoredSimplDevice.cs
@@ -156,7 +156,7 @@ namespace epi.utilities.deviceMonitor
             }
             catch (Exception ex)
             {
-                Debug.LogVerbose(this, "Exception - {0}", ex.Message);
+                Debug.LogInformation(this, "Exception - {0}", ex.Message);
             }
         }
 
@@ -174,7 +174,7 @@ namespace epi.utilities.deviceMonitor
             }
             catch (Exception ex)
             {
-                Debug.LogVerbose(this, "Exception - {0}", ex.Message);
+                Debug.LogInformation(this, "Exception - {0}", ex.Message);
             }
 
         }
@@ -211,7 +211,7 @@ namespace epi.utilities.deviceMonitor
             {
                 ChangeStatus(DeviceStatus.Error);
             }
-            Debug.LogInformation(this, "{0} Timer Expired", Status == DeviceStatus.Warning ? "Warning" : "Error" );
+            Debug.LogVerbose(this, "{0} Timer Expired", Status == DeviceStatus.Warning ? "Warning" : "Error" );
         }
 
         private void ChangeStatus(DeviceStatus status)
@@ -232,7 +232,7 @@ namespace epi.utilities.deviceMonitor
             }
             catch (Exception ex)
             {
-                Debug.LogVerbose(this, "Exception - {0}", ex.Message);
+                Debug.LogInformation(this, "Exception - {0}", ex.Message);
             }
         }
 

--- a/src/MonitoredSimplDevice.cs
+++ b/src/MonitoredSimplDevice.cs
@@ -156,7 +156,7 @@ namespace epi.utilities.deviceMonitor
             }
             catch (Exception ex)
             {
-                Debug.LogInformation(this, "Exception - {0}", ex.Message);
+                Debug.LogInformation(this, "Exception - {0}", ex.ToString());
             }
         }
 

--- a/src/epi-utilities-deviceMonitor.4Series.csproj
+++ b/src/epi-utilities-deviceMonitor.4Series.csproj
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<TargetFramework>net472</TargetFramework>
-		<RootNamespace>PepperDash.Essentials.Plugin.Utilities.DeviceMonitor</RootNamespace>
+		<RootNamespace>epi.utilities.deviceMonitor</RootNamespace>
 		<Deterministic>false</Deterministic>
 		<AssemblyTitle>EPI.Utilities.DeviceMonitor</AssemblyTitle>
 		<Company>PepperDash Technologies</Company>
@@ -15,7 +15,7 @@
 		<InformationalVersion>$(Version)</InformationalVersion>
 		<OutputPath>bin\$(Configuration)\</OutputPath>
 		<Authors>PepperDash Technologies</Authors>
-		<PackageId>PepperDash.Essentials.Plugins.Utilities.DeviceMonitor</PackageId>
+		<PackageId>PepperDash.Essentials.Plugin.DeviceMonitor</PackageId>
 		<PackageProjectUrl>https://github.com/PepperDash/epi-utilities-devicemonitor.git</PackageProjectUrl>
 		<PackageTags>crestron 4series essentials plugin device monitor</PackageTags>
 	</PropertyGroup>


### PR DESCRIPTION
Swap `Debug.LogVerbose()` and `Debug.LogInformation()` method calls as previous matched serilog levels instead of matching PepperDash Essentials `appdebug` levels. Changed CSPROJ packedgeId to match original allowing subsequent IDs to be deleted.